### PR TITLE
Add a workflow to release the apworld on tag/github release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release APWorld
+on:
+  push:
+    tags:
+      - '**'
+
+
+jobs:
+  apworld:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Make apworld
+        shell: bash
+        run: make pokemon_platinum.apworld
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: apworld
+          path: pokemon_platinum.apworld
+
+  template:
+    runs-on: ubuntu-latest
+    needs: [apworld]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: apworld
+
+      - uses: Eijebong/ap-actions/generate-template@main
+        id: template
+        with:
+          apworld-path: pokemon_platinum.apworld
+          apworld-name: pokemon_platinum
+          ap-version: "0.6.3"
+          python-version: "3.12"
+          checkout: false
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: template
+          path: ${{ steps.template.outputs.template }}
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [apworld, template]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: apworld
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: template
+
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: '*'
+          allowUpdates: true
+          prerelease: false
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true
+


### PR DESCRIPTION
This allows you to either create a github release and have CI automatically attach the built apworld and a default template to the release or to push a tag manually and have github create said release directly with the same artifacts.