### PR TITLE
Route 227 Access Fix

### DIFF
--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -452,18 +452,20 @@ trainers = [
 ]
 
 [route_227]
+accessible_encounters = [
+    "land",
+]
 exits = [
     "route_227_lower",
     "route_227_house",
+    "route_227_pit",
     "stark_mountain_outside",
 ]
 header = "route_227"
 locs = [
-    "route_227_charcoal",
     "route_227_zinc",
     "route_227_yellow_shard",
-    "route_227_star_piece",
-    "route_227_max_repel",
+    "route_227_star_piece"
 ]
 group = "fight_area"
 trainers = [
@@ -476,6 +478,23 @@ exits = [
 ]
 header = "route_227_house"
 group = "fight_area"
+
+[route_227_pit]
+accessible_encounters = [
+    "water",
+]
+exits = [
+    "route_227",
+]
+header = "route_227"
+locs = [
+    "route_227_charcoal",
+    "route_227_max_repel"
+]
+group = "fight_area"
+trainers = [
+    "black_belt_griffin",
+]
 
 [route_226_house]
 exits = [

--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -492,9 +492,6 @@ locs = [
     "route_227_max_repel"
 ]
 group = "fight_area"
-trainers = [
-    "black_belt_griffin",
-]
 
 [route_226_house]
 exits = [

--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -465,7 +465,7 @@ header = "route_227"
 locs = [
     "route_227_zinc",
     "route_227_yellow_shard",
-    "route_227_star_piece"
+    "route_227_star_piece",
 ]
 group = "fight_area"
 trainers = [
@@ -489,7 +489,7 @@ exits = [
 header = "route_227"
 locs = [
     "route_227_charcoal",
-    "route_227_max_repel"
+    "route_227_max_repel",
 ]
 group = "fight_area"
 

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -381,8 +381,7 @@ locs.route_225_dubious_disc = "surf"
 locs.route_225_dawn_stone = "rock_climb"
 
 exits.route_227_lower.route_227 = "bicycle & bag"
-locs.route_227_max_repel = "rock_climb"
-locs.route_227_charcoal = "rock_climb"
+exits.route_227.route_227_pit = "rock_climb"
 
 locs.stark_mountain_outside_life_orb = "rock_climb"
 exits.stark_mountain_room_1_entrance.stark_mountain_room_1 = "strength"


### PR DESCRIPTION
Water on Route 227 is only accessible with Rock Climb. This was not reflected in the apworld logic. I made a new region and also moved the two items of the pit into it.