### PR TITLE
Add Bag rules for evolving Feebas and Tyrogue

### DIFF
--- a/data_gen_templates/rules.py
+++ b/data_gen_templates/rules.py
@@ -130,7 +130,8 @@ class Rules:
         elif mthd == "level_ice_rock":
             reqd_items.append("event_ice_rock")
         if mthd in {"level_atk_gt_def", "level_atk_eq_def", "level_atk_lt_def"}:
-            reqd_items.extend(["event_veilstone_store", items.items["bag"].label])
+            reqd_items.append("event_veilstone_store")
+            reqd_items.append(items.items["bag"].label)
         if "beauty" in mthd:
             reqd_items.extend(["event_veilstone_city", items.items["poffin_case"].label, "event_hearthome_city", items.items["bag"].label])
 

--- a/data_gen_templates/rules.py
+++ b/data_gen_templates/rules.py
@@ -130,9 +130,9 @@ class Rules:
         elif mthd == "level_ice_rock":
             reqd_items.append("event_ice_rock")
         if mthd in {"level_atk_gt_def", "level_atk_eq_def", "level_atk_lt_def"}:
-            reqd_items.append("event_veilstone_store")
+            reqd_items.extend(["event_veilstone_store", items.items["bag"].label])
         if "beauty" in mthd:
-            reqd_items.extend(["event_veilstone_city", items.items["poffin_case"].label, "event_hearthome_city"])
+            reqd_items.extend(["event_veilstone_city", items.items["poffin_case"].label, "event_hearthome_city", items.items["bag"].label])
 
         def rule(state: CollectionState) -> bool:
             return state.has_all(reqd_items, self.player)

--- a/data_gen_templates/rules.py
+++ b/data_gen_templates/rules.py
@@ -130,8 +130,7 @@ class Rules:
         elif mthd == "level_ice_rock":
             reqd_items.append("event_ice_rock")
         if mthd in {"level_atk_gt_def", "level_atk_eq_def", "level_atk_lt_def"}:
-            reqd_items.append("event_veilstone_store")
-            reqd_items.append(items.items["bag"].label)
+            reqd_items.extend(["event_veilstone_store", items.items["bag"].label])
         if "beauty" in mthd:
             reqd_items.extend(["event_veilstone_city", items.items["poffin_case"].label, "event_hearthome_city", items.items["bag"].label])
 


### PR DESCRIPTION
Evolving Feebas requires the Poffin Case to feed it poffins to raise its beauty, and evolving Tyrogue logically requires access to the Veilstone Department Store so that you can use vitamins on it.
Both of these methods require the use of the Bag, but the rules don't seem to reflect that, so this changes that by adding explicit Bag requirements.
Neither method is directly flagged as an item requirement, so they skip the earlier catchall check, which is why they have to be added directly.