### PR TITLE
Fix Route 205 South fishing rules

### DIFF
--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -2656,7 +2656,7 @@ header = "canalave_library_3f"
 [route_205_south]
 exits = [
     "fuego_ironworks_outside",
-    "floaroma_town",
+    "route_205_south_bottom",
     "eterna_forest_outside",
     "route_205_house",
     "eterna_forest",
@@ -2681,10 +2681,21 @@ trainers = [
 ]
 honey_tree_idx = 0
 
+[route_205_south_bottom]
+exits = [
+    "floaroma_town",
+    "route_205_south",
+    "valley_windworks_outside",
+]
+header = "route_205_south"
+accessible_encounters = [
+    "water",
+]
+
 [valley_windworks_outside]
 exits = [
     "valley_windworks_building",
-    "floaroma_town",
+    "route_205_south_bottom",
 ]
 header = "valley_windworks_outside"
 locs = [
@@ -3055,12 +3066,11 @@ exits = [
     "floaroma_town_southeast_house",
     "floaroma_town_mart",
     "route_204_north",
-    "route_205_south",
+    "route_205_south_bottom",
     "floaroma_town_pokecenter_1f",
     "floaroma_meadow_south",
     "floaroma_town_middle_house",
     "flower_shop",
-    "valley_windworks_outside",
 ]
 header = "floaroma_town"
 

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -90,7 +90,7 @@ encs.ravaged_path.water = "rock_smash"
 
 locs.route_204_north_tm78 = "cut"
 
-exits.floaroma_town.route_205_south = "works_key | surf"
+exits.route_205_south_bottom.route_205_south = "works_key | surf"
 exits.valley_windworks_outside.valley_windworks_building = "works_key"
 exits.route_205_south.fuego_ironworks_outside = "surf"
 locs.valley_windworks_outside_tm24 = "surf"


### PR DESCRIPTION
Fishing on Route 205 South is possible from the very bottom part of the route accessed from Floaroma Town, but the current rules do not reflect this. This fixes that by adding a new `route_205_south_bottom` region connecting between `floaroma_town`, `valley_windworks_outside`, and `route_205_south` and making water encounters under the `route_205_south` header accessible through it.

The `floaroma_town` <-> `valley_windworks_outside` connections were also removed in favor of using `route_205_south_bottom` to bridge the two regions, as is the case in-game.