### PR TITLE
Fix some Route 227 trainers missing Bicycle requirement

### DIFF
--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -445,11 +445,6 @@ exits = [
     "route_227",
     "route_226_east",
 ]
-trainers = [
-    "ace_trainer_saul",
-    "ranger_felicia",
-    "ace_trainer_mikayla",
-]
 
 [route_227]
 accessible_encounters = [
@@ -469,6 +464,9 @@ locs = [
 ]
 group = "fight_area"
 trainers = [
+    "ace_trainer_saul",
+    "ranger_felicia",
+    "ace_trainer_mikayla",
     "black_belt_griffin",
 ]
 

--- a/data_gen/trainers.toml
+++ b/data_gen/trainers.toml
@@ -4561,7 +4561,7 @@ id = 564
 party = [
     { species = "tauros", level = 61, num_moves = 4 },
 ]
-label = "Route 227 Lower - Ace Trainer Saul"
+label = "Route 227 - Ace Trainer Saul"
 requires_national_dex = true
 
 [ace_trainer_jose]
@@ -4674,7 +4674,7 @@ party = [
     { species = "persian", level = 56, num_moves = 4 },
     { species = "absol", level = 56, num_moves = 4 },
 ]
-label = "Route 227 Lower - Ace Trainer Mikayla"
+label = "Route 227 - Ace Trainer Mikayla"
 requires_national_dex = true
 
 [ace_trainer_meagan]
@@ -4851,7 +4851,7 @@ party = [
     { species = "skiploom", level = 59, num_moves = 0 },
     { species = "lopunny", level = 59, num_moves = 0 },
 ]
-label = "Route 227 Lower - Ranger Felicia"
+label = "Route 227 - Ranger Felicia"
 requires_national_dex = true
 
 [ranger_krista]


### PR DESCRIPTION
A few trainers on Route 227 were listed in the `route_227_lower` region, which is inaccurate as those trainers are located past the Bicycle jumps, meaning they should be in `route_227` proper.
This moves them and also changes the names of their trainersanity locations to reflect their new region.