### PR TITLE
Connect Fight Area to Snowpoint City

### DIFF
--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -995,6 +995,7 @@ header = "twinleaf_town_southwest_house"
 
 [fight_area]
 exits = [
+    "snowpoint_city",
     "route_225_gate_to_fight_area",
     "fight_area_middle_house",
     "fight_area_mart",


### PR DESCRIPTION
There is currently no exit leading from `fight_area` to `snowpoint_city`. However, in-game, the player can freely use the boat to go from the Fight Area to Snowpoint City with no additional requirements as far as I can tell. This fixes that discrepancy by adding a connection back from `fight_area` to `snowpoint_city`.