### PR TITLE
Add Surf & Down Waterfall requirements from League South to R223

### DIFF
--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -373,6 +373,7 @@ locs.route_223_heart_scale = "surf"
 locs.route_223_heart_scale_0 = "surf"
 exits.route_223.pokemon_league_south_south = "surf"
 exits.pokemon_league_south_south.pokemon_league_south = "surf & waterfall"
+exits.pokemon_league_south.pokemon_league_south_south = "surf & down_waterfall"
 
 locs.victory_road_2f_tm71 = "bicycle & bag"
 locs.victory_road_2f_full_restore = "bicycle & bag"


### PR DESCRIPTION
Adds a requirement for `surf & down_waterfall` to the connection from `pokemon_league_south` to `pokemon_league_south_south`.