### PR TITLE
Add Surf rules to Lake Acuity

### DIFF
--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -344,6 +344,10 @@ locs.route_217_west_house_icicle_plate = "hm08"
 locs.acuity_lakefront_reaper_cloth = "rock_climb"
 exits.acuity_lakefront.lake_acuity_low_water = "rock_climb"
 
+locs.lake_acuity_tm14 = "surf"
+encs.lake_acuity.land = "surf"
+exits.lake_acuity.acuity_cavern = "surf"
+
 exits.snowpoint_city.fight_area = "s_s_ticket"
 exits.snowpoint_city.snowpoint_temple_1f = "national_dex & event_beat_cynthia"
 locs.snowpoint_temple_b4f_full_heal = "strength"


### PR DESCRIPTION
Currently, Lake Acuity's land encounters and TM location do not have Surf rules applied to them, despite you needing to cross the lake in order to reach them.
This was previously not an issue due to Surf being needed to trigger the sequence that raised the water level of the lake, but there are now multiple methods of completing the sequence without needing Surf, so these rules have become necessary.

The Acuity Cavern rule is technically not needed because the region does not do anything (and Uxie within requires clearing the Distortion World, which still always needs Surf) but was applied to match Verity Cavern having an equivalent rule.