### PR TITLE
Remove Strength requirement for Mars and Jupiter in Stark Mountain

### DIFF
--- a/data_gen/regions.toml
+++ b/data_gen/regions.toml
@@ -1692,6 +1692,11 @@ exits = [
     "stark_mountain_room_1",
 ]
 header = "stark_mountain_room_1"
+group = "fight_area"
+trainers = [
+    "commander_mars_stark_mountain",
+    "commander_jupiter_stark_mountain",
+]
 
 [stark_mountain_room_1]
 exits = [
@@ -1707,10 +1712,6 @@ locs = [
     "stark_mountain_room_1_star_piece",
 ]
 group = "fight_area"
-trainers = [
-    "commander_mars_stark_mountain",
-    "commander_jupiter_stark_mountain",
-]
 
 [battle_frontier_gate_to_fight_area]
 exits = [


### PR DESCRIPTION
The fights with Mars and Jupiter in Stark Mountain were located in the `stark_mountain_room_1` region, which requires Strength, however they fight you as soon as you enter the room without any need to use Strength. Therefore they have been moved into the `stark_mountain_room_1_entrance` region, before the requirement.

This also puts the `stark_mountain_room_1_entrance` region into the `fight_area` group. I'm not actually entirely sure what this does in particular, but it seemed to be missing for this region.