### PR TITLE
Add Special Encounters and Roamers to hint data

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -238,6 +238,14 @@ class PokemonPlatinumWorld(World):
             for key, mon in self.generated_encounters.items():
                 if mon in dexsanity_specs:
                     dexsanity_hint_data[mon].add(encounter_slot_label(key, self.options.in_logic_encounters.value))
+            for (speenc, _), mon in self.generated_speencs.items():
+                if mon in dexsanity_specs:
+                    dexsanity_hint_data[mon].add(speenc_labels[speenc])
+            if self.options.randomize_roamers and "roamers" in self.options.in_logic_encounters.value:
+                for i, mon in enumerate(self.generated_roamers):
+                    if mon in dexsanity_specs:
+                        dexsanity_hint_data[mon].add(roamer_labels[i])
+
 
         #am_set = set(self.accessible_mons)
         #def get_dexsanity_evolution_hint_data(dexsanity_hint_data: dict[str, set[str]]) -> None:
@@ -272,7 +280,7 @@ class PokemonPlatinumWorld(World):
                 encounters_per_pokemon[mon].add(encounter_slot_label(key, self.options.in_logic_encounters.value))
             for (speenc, _), mon in self.generated_speencs.items():
                 encounters_per_pokemon[mon].add(speenc_labels[speenc])
-        if self.options.randomize_roamers:
+        if self.options.randomize_roamers and "roamers" in self.options.in_logic_encounters.value:
             for i, mon in enumerate(self.generated_roamers):
                 encounters_per_pokemon[mon].add(roamer_labels[i])
 


### PR DESCRIPTION
Rudimentary implementation of special encounters and roamers being added to hint data, based on the way they are added to the spoiler log.
The data used is the same, so Munchlax trees are just displayed as `Honey Tree (Munchlax)`, and it does not actually explain where the Munchlax trees are located.

Also disabled roamers being displayed in the spoiler log even if they're out of logic, matching the behavior of the other encounter methods.

I did some test gens with these changes applied to current main and did not notice any issues, but I have not tested them very thoroughly at this time.