### PR TITLE
Add proper requirements for the ability to bypass Route 210 Lower and Route 215 roadblocks

### DIFF
--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -343,9 +343,34 @@ common.bicycle_through_route_210_barricade = """
         | route_210_lower_barricade == option_waterfall_and_rock_smash
         | route_210_lower_barricade == option_waterfall_and_strength_boulder
         | route_210_lower_barricade == option_waterfall_and_psyduck
+    else bag | rock_climb
+    if route_210_lower_barricade == option_rock_climb
+    else bag | cut
+    if route_210_lower_barricade == option_cut_tree
+        | route_210_lower_barricade == option_bicycle_slope_and_cut_tree
+    else bag | rock_smash
+    if route_210_lower_barricade == option_rock_smash
+        | route_210_lower_barricade == option_bicycle_slope_and_rock_smash
+    else bag | strength
+    if route_210_lower_barricade == option_strength_boulder
+        | route_210_lower_barricade == option_bicycle_slope_and_strength_boulder
+    else bag | secretpotion
+    if route_210_lower_barricade == option_psyduck
+        | route_210_lower_barricade == option_bicycle_slope_and_psyduck
+    else bag | (rock_climb & cut)
+    if route_210_lower_barricade == option_rock_climb_and_cut_tree
+    else bag | (rock_climb & rock_smash)
+    if route_210_lower_barricade == option_rock_climb_and_rock_smash
+    else bag | (rock_climb & strength)
+    if route_210_lower_barricade == option_rock_climb_and_strength_boulder
+    else bag | (rock_climb & secretpotion)
+    if route_210_lower_barricade == option_rock_climb_and_psyduck
+    else True
+    if route_210_lower_barricade == option_none
+        | route_210_lower_barricade == option_bicycle_slope
 """
 
-common.veilstone_bicycle_from_solaceon = """
+common.bicycle_through_route_215_barricade = """
     bag
     if route_215_barricade == option_impassable
         | route_215_barricade == option_surf
@@ -358,8 +383,34 @@ common.veilstone_bicycle_from_solaceon = """
         | route_215_barricade == option_waterfall_and_rock_smash
         | route_215_barricade == option_waterfall_and_strength_boulder
         | route_215_barricade == option_waterfall_and_psyduck
-    else bicycle_through_route_210_barricade
+    else bag | rock_climb
+    if route_215_barricade == option_rock_climb
+    else bag | cut
+    if route_215_barricade == option_cut_tree
+        | route_215_barricade == option_bicycle_bridge_and_cut_tree
+    else bag | rock_smash
+    if route_215_barricade == option_rock_smash
+        | route_215_barricade == option_bicycle_bridge_and_rock_smash
+    else bag | strength
+    if route_215_barricade == option_strength_boulder
+        | route_215_barricade == option_bicycle_bridge_and_strength_boulder
+    else bag | secretpotion
+    if route_215_barricade == option_psyduck
+        | route_215_barricade == option_bicycle_bridge_and_psyduck
+    else bag | (rock_climb & cut)
+    if route_215_barricade == option_rock_climb_and_cut_tree
+    else bag | (rock_climb & rock_smash)
+    if route_215_barricade == option_rock_climb_and_rock_smash
+    else bag | (rock_climb & strength)
+    if route_215_barricade == option_rock_climb_and_strength_boulder
+    else bag | (rock_climb & secretpotion)
+    if route_215_barricade == option_rock_climb_and_psyduck
+    else True
+    if route_215_barricade == option_none
+        | route_215_barricade == option_bicycle_bridge
 """
+
+common.veilstone_bicycle_from_solaceon = "bicycle_through_route_210_barricade & bicycle_through_route_215_barricade"
 
 locs.jubilife_city_fashion_case = "event_coal_badge"
 exits.jubilife_city.jubilife_tv_1f = "event_coal_badge"

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -131,7 +131,7 @@ exits.route_207.route_207_south = """
     else rock_climb & secretpotion
     if route_207_barricade == option_rock_climb_and_psyduck
 """
-exits.route_210_south.route_210_junction = """
+common.route_210_south_to_route_210_junction = """
     bicycle
     if route_210_lower_barricade == option_bicycle_slope
     else rock_climb
@@ -183,6 +183,7 @@ exits.route_210_south.route_210_junction = """
     else surf & waterfall & secretpotion
     if route_210_lower_barricade == option_waterfall_and_psyduck
 """
+exits.route_210_south.route_210_junction = "route_210_south_to_route_210_junction"
 exits.route_210_junction.route_210_south = """
     rock_climb
     if route_210_lower_barricade == option_rock_climb
@@ -277,7 +278,7 @@ exits.route_215.route_210_junction = """
     else surf & down_waterfall & secretpotion
     if route_215_barricade == option_waterfall_and_psyduck
 """
-exits.route_210_junction.route_215 = """
+common.route_210_junction_to_route_215 = """
     bicycle_through_route_210_barricade & bicycle
     if route_215_barricade == option_bicycle_bridge
     else rock_climb
@@ -329,6 +330,7 @@ exits.route_210_junction.route_215 = """
     else surf & waterfall & secretpotion
     if route_215_barricade == option_waterfall_and_psyduck
 """
+exits.route_210_junction.route_215 = "route_210_junction_to_route_215"
 
 common.bicycle_through_route_210_barricade = """
     bag
@@ -343,33 +345,8 @@ common.bicycle_through_route_210_barricade = """
         | route_210_lower_barricade == option_waterfall_and_rock_smash
         | route_210_lower_barricade == option_waterfall_and_strength_boulder
         | route_210_lower_barricade == option_waterfall_and_psyduck
-    else bag | rock_climb
-    if route_210_lower_barricade == option_rock_climb
-    else bag | cut
-    if route_210_lower_barricade == option_cut_tree
-        | route_210_lower_barricade == option_bicycle_slope_and_cut_tree
-    else bag | rock_smash
-    if route_210_lower_barricade == option_rock_smash
-        | route_210_lower_barricade == option_bicycle_slope_and_rock_smash
-    else bag | strength
-    if route_210_lower_barricade == option_strength_boulder
-        | route_210_lower_barricade == option_bicycle_slope_and_strength_boulder
-    else bag | secretpotion
-    if route_210_lower_barricade == option_psyduck
-        | route_210_lower_barricade == option_bicycle_slope_and_psyduck
-    else bag | (rock_climb & cut)
-    if route_210_lower_barricade == option_rock_climb_and_cut_tree
-    else bag | (rock_climb & rock_smash)
-    if route_210_lower_barricade == option_rock_climb_and_rock_smash
-    else bag | (rock_climb & strength)
-    if route_210_lower_barricade == option_rock_climb_and_strength_boulder
-    else bag | (rock_climb & secretpotion)
-    if route_210_lower_barricade == option_rock_climb_and_psyduck
-    else True
-    if route_210_lower_barricade == option_none
-        | route_210_lower_barricade == option_bicycle_slope
+    else bag | route_210_south_to_route_210_junction
 """
-
 common.bicycle_through_route_215_barricade = """
     bag
     if route_215_barricade == option_impassable
@@ -383,31 +360,7 @@ common.bicycle_through_route_215_barricade = """
         | route_215_barricade == option_waterfall_and_rock_smash
         | route_215_barricade == option_waterfall_and_strength_boulder
         | route_215_barricade == option_waterfall_and_psyduck
-    else bag | rock_climb
-    if route_215_barricade == option_rock_climb
-    else bag | cut
-    if route_215_barricade == option_cut_tree
-        | route_215_barricade == option_bicycle_bridge_and_cut_tree
-    else bag | rock_smash
-    if route_215_barricade == option_rock_smash
-        | route_215_barricade == option_bicycle_bridge_and_rock_smash
-    else bag | strength
-    if route_215_barricade == option_strength_boulder
-        | route_215_barricade == option_bicycle_bridge_and_strength_boulder
-    else bag | secretpotion
-    if route_215_barricade == option_psyduck
-        | route_215_barricade == option_bicycle_bridge_and_psyduck
-    else bag | (rock_climb & cut)
-    if route_215_barricade == option_rock_climb_and_cut_tree
-    else bag | (rock_climb & rock_smash)
-    if route_215_barricade == option_rock_climb_and_rock_smash
-    else bag | (rock_climb & strength)
-    if route_215_barricade == option_rock_climb_and_strength_boulder
-    else bag | (rock_climb & secretpotion)
-    if route_215_barricade == option_rock_climb_and_psyduck
-    else True
-    if route_215_barricade == option_none
-        | route_215_barricade == option_bicycle_bridge
+    else bag | route_210_junction_to_route_215
 """
 
 common.veilstone_bicycle_from_solaceon = "bicycle_through_route_210_barricade & bicycle_through_route_215_barricade"

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -360,7 +360,7 @@ common.bicycle_through_route_215_barricade = """
         | route_215_barricade == option_waterfall_and_rock_smash
         | route_215_barricade == option_waterfall_and_strength_boulder
         | route_215_barricade == option_waterfall_and_psyduck
-    else bag | bicycle_through_route_210_barricade
+    else bag | route_210_junction_to_route_215
 """
 
 common.veilstone_bicycle_from_solaceon = "bicycle_through_route_210_barricade & bicycle_through_route_215_barricade"

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -360,7 +360,7 @@ common.bicycle_through_route_215_barricade = """
         | route_215_barricade == option_waterfall_and_rock_smash
         | route_215_barricade == option_waterfall_and_strength_boulder
         | route_215_barricade == option_waterfall_and_psyduck
-    else bag | route_210_junction_to_route_215
+    else bag | bicycle_through_route_210_barricade
 """
 
 common.veilstone_bicycle_from_solaceon = "bicycle_through_route_210_barricade & bicycle_through_route_215_barricade"

--- a/data_gen/rules.toml
+++ b/data_gen/rules.toml
@@ -184,6 +184,21 @@ common.route_210_south_to_route_210_junction = """
     if route_210_lower_barricade == option_waterfall_and_psyduck
 """
 exits.route_210_south.route_210_junction = "route_210_south_to_route_210_junction"
+common.bicycle_through_route_210_barricade = """
+    bag
+    if route_210_lower_barricade == option_impassable
+        | route_210_lower_barricade == option_surf
+        | route_210_lower_barricade == option_surf_and_cut_tree
+        | route_210_lower_barricade == option_surf_and_rock_smash
+        | route_210_lower_barricade == option_surf_and_strength_boulder
+        | route_210_lower_barricade == option_surf_and_psyduck
+        | route_210_lower_barricade == option_waterfall
+        | route_210_lower_barricade == option_waterfall_and_cut_tree
+        | route_210_lower_barricade == option_waterfall_and_rock_smash
+        | route_210_lower_barricade == option_waterfall_and_strength_boulder
+        | route_210_lower_barricade == option_waterfall_and_psyduck
+    else bag | route_210_south_to_route_210_junction
+"""
 exits.route_210_junction.route_210_south = """
     rock_climb
     if route_210_lower_barricade == option_rock_climb
@@ -332,21 +347,6 @@ common.route_210_junction_to_route_215 = """
 """
 exits.route_210_junction.route_215 = "route_210_junction_to_route_215"
 
-common.bicycle_through_route_210_barricade = """
-    bag
-    if route_210_lower_barricade == option_impassable
-        | route_210_lower_barricade == option_surf
-        | route_210_lower_barricade == option_surf_and_cut_tree
-        | route_210_lower_barricade == option_surf_and_rock_smash
-        | route_210_lower_barricade == option_surf_and_strength_boulder
-        | route_210_lower_barricade == option_surf_and_psyduck
-        | route_210_lower_barricade == option_waterfall
-        | route_210_lower_barricade == option_waterfall_and_cut_tree
-        | route_210_lower_barricade == option_waterfall_and_rock_smash
-        | route_210_lower_barricade == option_waterfall_and_strength_boulder
-        | route_210_lower_barricade == option_waterfall_and_psyduck
-    else bag | route_210_south_to_route_210_junction
-"""
 common.bicycle_through_route_215_barricade = """
     bag
     if route_215_barricade == option_impassable


### PR DESCRIPTION
Currently, the conditions checking for additional rules to be added for biking through Route 210 Lower and Route 215 only ever check if they would be completely impossible without the Bag.

However, when the routes would eventually become traversable with additional items, these rules are not applied to the conditions checking if they can be passed through with the Bicycle, which could result in the player being expected to access locations that they cannot reach without the items needed to bypass the roadblock (or the Bag).

This fixes the above issue by checking for each possible scenario and adding additional rules to bike traversal when necessary.