### PR TITLE
Label Update 4

### DIFF
--- a/data_gen/locations.toml
+++ b/data_gen/locations.toml
@@ -3146,7 +3146,7 @@ check = 1131
 label = "Route 210 North - Item Under Bridge Next to Hidden Ninja Boy"
 id = 117
 
-[_north_tm30]
+[route_210_north_tm30]
 original_item = "tm30"
 type = "overworld"
 table = "overworld"
@@ -3154,7 +3154,7 @@ check = 1133
 label = "Route 210 North - Item Behind Breakable Rocks"
 id = 119
 
-[_north_wave_incense]
+[route_210_north_wave_incense]
 original_item = "wave_incense"
 type = "overworld"
 table = "overworld"
@@ -3162,7 +3162,7 @@ check = 1132
 label = "Route 210 North - Item Under West Bridge"
 id = 118
 
-[_north_zinc]
+[route_210_north_zinc]
 original_item = "zinc"
 type = "overworld"
 table = "overworld"
@@ -3170,7 +3170,7 @@ check = 1294
 label = "Route 210 Center - Item on Ledge Below Move Tutor"
 id = 279
 
-[_south_full_heal]
+[route_210_south_full_heal]
 original_item = "full_heal"
 type = "hidden"
 table = "hidden"
@@ -3178,7 +3178,7 @@ check = 769
 label = "Route 210 Center - Hidden Item in Long Grass Lower Left"
 id = 39
 
-[_south_hyper_potion]
+[route_210_south_hyper_potion]
 original_item = "hyper_potion"
 type = "overworld"
 table = "overworld"
@@ -3186,7 +3186,7 @@ check = 1117
 label = "Route 210 Center - Item in Center"
 id = 103
 
-[_south_hyper_potion_0]
+[route_210_south_hyper_potion_0]
 original_item = "hyper_potion"
 type = "hidden"
 table = "hidden"
@@ -3194,7 +3194,7 @@ check = 919
 label = "Route 210 Center - Hidden Item in Long Grass Lower Right"
 id = 189
 
-[_south_max_repel]
+[route_210_south_max_repel]
 original_item = "max_repel"
 type = "overworld"
 table = "overworld"
@@ -3202,7 +3202,7 @@ check = 1114
 label = "Route 210 Center - Item Near Bottom Left Tree in Long Grass"
 id = 100
 
-[_south_nest_ball]
+[route_210_south_nest_ball]
 original_item = "nest_ball"
 type = "overworld"
 table = "overworld"
@@ -3210,7 +3210,7 @@ check = 1116
 label = "Route 210 Center - Item in Northeast Grass Corner"
 id = 102
 
-[_south_old_charm]
+[route_210_south_old_charm]
 id = 79
 check = 263
 original_item = "old_charm"
@@ -3218,7 +3218,7 @@ type = "key_item"
 table = "base"
 label = "Route 210 South - Third Item from Cynthia"
 
-[_south_rare_candy]
+[route_210_south_rare_candy]
 original_item = "rare_candy"
 type = "hidden"
 table = "hidden"
@@ -3226,7 +3226,7 @@ check = 884
 label = "Route 210 South - Hidden Item in Grass Next to Honey Tree"
 id = 154
 
-[_south_super_repel]
+[route_210_south_super_repel]
 original_item = "super_repel"
 type = "overworld"
 table = "overworld"
@@ -3234,7 +3234,7 @@ check = 1113
 label = "Route 210 South - Item in Northwest Corner"
 id = 99
 
-[_south_tm51]
+[route_210_south_tm51]
 id = 78
 check = 199
 original_item = "tm51"
@@ -3242,7 +3242,7 @@ type = "npc_gift"
 table = "base"
 label = "Route 210 South - Gift from Girl on Hill"
 
-[_south_ultra_ball]
+[route_210_south_ultra_ball]
 original_item = "ultra_ball"
 type = "hidden"
 table = "hidden"
@@ -3250,7 +3250,7 @@ check = 879
 label = "Route 210 Center - Hidden Item in Long Grass Upper Left"
 id = 149
 
-[_south_ultra_ball_0]
+[route_210_south_ultra_ball_0]
 original_item = "ultra_ball"
 type = "hidden"
 table = "hidden"

--- a/data_gen/locations.toml
+++ b/data_gen/locations.toml
@@ -3127,7 +3127,7 @@ original_item = "red_shard"
 type = "overworld"
 table = "overworld"
 check = 1293
-label = "Route 210 North - Item to Left of Grass"
+label = "Route 210 Center - Item to Left of Grass"
 id = 278
 
 [route_210_north_shiny_stone]
@@ -3135,7 +3135,7 @@ original_item = "shiny_stone"
 type = "hidden"
 table = "hidden"
 check = 775
-label = "Route 210 North - Hidden Item on Ledge in Pit"
+label = "Route 210 Center - Hidden Item on Ledge in Pit"
 id = 45
 
 [route_210_north_smoke_ball]
@@ -3146,7 +3146,7 @@ check = 1131
 label = "Route 210 North - Item Under Bridge Next to Hidden Ninja Boy"
 id = 117
 
-[route_210_north_tm30]
+[_north_tm30]
 original_item = "tm30"
 type = "overworld"
 table = "overworld"
@@ -3154,7 +3154,7 @@ check = 1133
 label = "Route 210 North - Item Behind Breakable Rocks"
 id = 119
 
-[route_210_north_wave_incense]
+[_north_wave_incense]
 original_item = "wave_incense"
 type = "overworld"
 table = "overworld"
@@ -3162,55 +3162,55 @@ check = 1132
 label = "Route 210 North - Item Under West Bridge"
 id = 118
 
-[route_210_north_zinc]
+[_north_zinc]
 original_item = "zinc"
 type = "overworld"
 table = "overworld"
 check = 1294
-label = "Route 210 North - Item on Ledge Below Move Tutor"
+label = "Route 210 Center - Item on Ledge Below Move Tutor"
 id = 279
 
-[route_210_south_full_heal]
+[_south_full_heal]
 original_item = "full_heal"
 type = "hidden"
 table = "hidden"
 check = 769
-label = "Route 210 Middle - Hidden Item in Long Grass Lower Left"
+label = "Route 210 Center - Hidden Item in Long Grass Lower Left"
 id = 39
 
-[route_210_south_hyper_potion]
+[_south_hyper_potion]
 original_item = "hyper_potion"
 type = "overworld"
 table = "overworld"
 check = 1117
-label = "Route 210 Middle - Item in Center"
+label = "Route 210 Center - Item in Center"
 id = 103
 
-[route_210_south_hyper_potion_0]
+[_south_hyper_potion_0]
 original_item = "hyper_potion"
 type = "hidden"
 table = "hidden"
 check = 919
-label = "Route 210 Middle - Hidden Item in Long Grass Lower Right"
+label = "Route 210 Center - Hidden Item in Long Grass Lower Right"
 id = 189
 
-[route_210_south_max_repel]
+[_south_max_repel]
 original_item = "max_repel"
 type = "overworld"
 table = "overworld"
 check = 1114
-label = "Route 210 Middle - Item Near Bottom Left Tree in Long Grass"
+label = "Route 210 Center - Item Near Bottom Left Tree in Long Grass"
 id = 100
 
-[route_210_south_nest_ball]
+[_south_nest_ball]
 original_item = "nest_ball"
 type = "overworld"
 table = "overworld"
 check = 1116
-label = "Route 210 Middle - Item in Northeast Grass Corner"
+label = "Route 210 Center - Item in Northeast Grass Corner"
 id = 102
 
-[route_210_south_old_charm]
+[_south_old_charm]
 id = 79
 check = 263
 original_item = "old_charm"
@@ -3218,7 +3218,7 @@ type = "key_item"
 table = "base"
 label = "Route 210 South - Third Item from Cynthia"
 
-[route_210_south_rare_candy]
+[_south_rare_candy]
 original_item = "rare_candy"
 type = "hidden"
 table = "hidden"
@@ -3226,7 +3226,7 @@ check = 884
 label = "Route 210 South - Hidden Item in Grass Next to Honey Tree"
 id = 154
 
-[route_210_south_super_repel]
+[_south_super_repel]
 original_item = "super_repel"
 type = "overworld"
 table = "overworld"
@@ -3234,7 +3234,7 @@ check = 1113
 label = "Route 210 South - Item in Northwest Corner"
 id = 99
 
-[route_210_south_tm51]
+[_south_tm51]
 id = 78
 check = 199
 original_item = "tm51"
@@ -3242,20 +3242,20 @@ type = "npc_gift"
 table = "base"
 label = "Route 210 South - Gift from Girl on Hill"
 
-[route_210_south_ultra_ball]
+[_south_ultra_ball]
 original_item = "ultra_ball"
 type = "hidden"
 table = "hidden"
 check = 879
-label = "Route 210 Middle - Hidden Item in Long Grass Upper Left"
+label = "Route 210 Center - Hidden Item in Long Grass Upper Left"
 id = 149
 
-[route_210_south_ultra_ball_0]
+[_south_ultra_ball_0]
 original_item = "ultra_ball"
 type = "hidden"
 table = "hidden"
 check = 932
-label = "Route 210 Middle - Hidden Item in Long Grass Upper Right"
+label = "Route 210 Center - Hidden Item in Long Grass Upper Right"
 id = 202
 
 [route_211_east_calcium]

--- a/data_gen/locations.toml
+++ b/data_gen/locations.toml
@@ -2621,7 +2621,7 @@ original_item = "awakening"
 type = "overworld"
 table = "overworld"
 check = 1268
-label = "Upper Route 204 - Item Above Cave Entrance"
+label = "Route 204 North - Item Above Cave Entrance"
 id = 254
 
 [route_204_north_tm09]
@@ -2629,7 +2629,7 @@ original_item = "tm09"
 type = "overworld"
 table = "overworld"
 check = 1028
-label = "Upper Route 204 - Item on Left"
+label = "Route 204 North - Item on Left"
 id = 14
 
 [route_204_north_tm78]
@@ -2637,7 +2637,7 @@ original_item = "tm78"
 type = "npc_gift"
 table = "base"
 check = 197
-label = "Upper Route 204 - Woman Behind Cut Tree"
+label = "Route 204 North - Woman Behind Cut Tree"
 id = 54
 
 [route_204_south_hp_up]
@@ -2645,7 +2645,7 @@ original_item = "hp_up"
 type = "overworld"
 table = "overworld"
 check = 1024
-label = "Route 204 - Item Behind Eastern Pond"
+label = "Route 204 South - Item Behind Eastern Pond"
 id = 10
 
 [route_204_south_parlyz_heal]
@@ -2653,7 +2653,7 @@ original_item = "parlyz_heal"
 type = "overworld"
 table = "overworld"
 check = 1096
-label = "Route 204 - Item Behind Small Pond"
+label = "Route 204 South - Item Behind Small Pond"
 id = 82
 
 [route_204_south_sea_incense]
@@ -2661,7 +2661,7 @@ original_item = "sea_incense"
 type = "overworld"
 table = "overworld"
 check = 1023
-label = "Route 204 - Item Behind Southwest Pond"
+label = "Route 204 South - Item Behind Southwest Pond"
 id = 9
 
 [route_205_north_guard_spec]
@@ -2669,7 +2669,7 @@ original_item = "guard_spec"
 type = "overworld"
 table = "overworld"
 check = 1037
-label = "Route 205 - Item South of Pond"
+label = "Route 205 North - Item South of Pond"
 id = 23
 
 [route_205_south_heal_ball]

--- a/data_gen/trainers.toml
+++ b/data_gen/trainers.toml
@@ -518,7 +518,7 @@ party = [
     { species = "girafarig", level = 32, num_moves = 4 },
     { species = "grotle", level = 33, num_moves = 3 },
 ]
-label = "Route 210 North - Ace Trainer Alyssa"
+label = "Route 210 Center - Ace Trainer Alyssa"
 
 [veteran_brian]
 id = 68
@@ -544,7 +544,7 @@ party = [
     { species = "stunky", level = 29, num_moves = 0 },
     { species = "golbat", level = 29, num_moves = 0 },
 ]
-label = "Route 210 North - Ninja Boy Joel"
+label = "Route 210 Center - Ninja Boy Joel"
 
 [ninja_boy_nathan]
 id = 71
@@ -566,7 +566,7 @@ id = 73
 party = [
     { species = "gible", level = 34, num_moves = 0 },
 ]
-label = "Route 210 North - Dragon Tamer Patrick"
+label = "Route 210 Center - Dragon Tamer Patrick"
 
 [bird_keeper_brianna]
 id = 74
@@ -2178,14 +2178,14 @@ id = 275
 party = [
     { species = "heracross", level = 25, num_moves = 0 },
 ]
-label = "Route 210 South - Collector Fernando"
+label = "Route 210 Cafe Cabin - Collector Fernando"
 
 [collector_edwin]
 id = 276
 party = [
     { species = "munchlax", level = 25, num_moves = 0 },
 ]
-label = "Route 210 South - Collector Edwin"
+label = "Route 210 Cafe Cabin - Collector Edwin"
 
 [dragon_tamer_hayden]
 id = 277
@@ -2906,7 +2906,7 @@ id = 366
 party = [
     { species = "clefairy", level = 25, num_moves = 0 },
 ]
-label = "Route 210 South - Waitress Kati"
+label = "Route 210 Cafe Cabin - Waitress Kati"
 
 [worker_gerardo]
 id = 367
@@ -3950,7 +3950,7 @@ party = [
     { species = "croagunk", level = 31, num_moves = 0 },
     { species = "croagunk", level = 31, num_moves = 0 },
 ]
-label = "Route 210 South - Ninja Boy Fabian"
+label = "Route 210 Center - Ninja Boy Fabian"
 
 [ninja_boy_brennan]
 id = 489
@@ -3958,14 +3958,14 @@ party = [
     { species = "zubat", level = 30, num_moves = 0 },
     { species = "skorupi", level = 32, num_moves = 0 },
 ]
-label = "Route 210 South - Ninja Boy Brennan"
+label = "Route 210 Center - Ninja Boy Brennan"
 
 [ninja_boy_bruce]
 id = 490
 party = [
     { species = "stunky", level = 33, num_moves = 0 },
 ]
-label = "Route 210 South - Ninja Boy Bruce"
+label = "Route 210 Center - Ninja Boy Bruce"
 
 [beauty_devon]
 id = 491


### PR DESCRIPTION
This changes:
 r204 to use a consistent naming scheme for all of its checks
 fixes a single r205 item name
 redoes all of r210 into North, Center, South, and Cafe Cabin. These align to which map they are on in the tracker 